### PR TITLE
fix: udate Helm repositories and releases to new helm-charts location

### DIFF
--- a/docs/getting-started/apps/base/account-operator/release.yaml
+++ b/docs/getting-started/apps/base/account-operator/release.yaml
@@ -9,3 +9,5 @@ spec:
     kind: OCIRepository
     name: account-operator
   releaseName: account-operator
+  values:
+    imagePullSecret: ghcr-credentials

--- a/docs/getting-started/apps/base/account-operator/repository.yaml
+++ b/docs/getting-started/apps/base/account-operator/repository.yaml
@@ -5,6 +5,8 @@ metadata:
   namespace: openmfp-system
 spec:
   interval: 5m
-  url: oci://ghcr.io/openmfp/account-operator/helm/account-operator
+  url: oci://ghcr.io/openmfp/helm-charts/account-operator
   ref:
     semver: "*"
+  secretRef:
+    name: ghcr-credentials

--- a/docs/getting-started/apps/base/account-ui/repository.yaml
+++ b/docs/getting-started/apps/base/account-ui/repository.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: openmfp-system
 spec:
   interval: 5m
-  url: oci://ghcr.io/openmfp/account-ui/helm/account-ui
+  url: oci://ghcr.io/openmfp/helm-charts/account-ui
   ref:
     semver: "*"
   secretRef:

--- a/docs/getting-started/apps/base/crd-gateway/repository.yaml
+++ b/docs/getting-started/apps/base/crd-gateway/repository.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: openmfp-system
 spec:
   interval: 5m
-  url: oci://ghcr.io/openmfp/example-crd-gateway/helm/example-crd-gateway
+  url: oci://ghcr.io/openmfp/helm-charts/example-crd-gateway
   ref:
     semver: "*"
   secretRef: # TODO: temporary as long as the repo is private

--- a/docs/getting-started/apps/base/extension-content-operator/release.yaml
+++ b/docs/getting-started/apps/base/extension-content-operator/release.yaml
@@ -10,4 +10,4 @@ spec:
     name: extension-content-operator
   releaseName: extension-content-operator
   values:
-    imagePullSecrets: ghcr-credentials # TODO: temporary as long as the repo is private
+    imagePullSecret: ghcr-credentials # TODO: temporary as long as the repo is private

--- a/docs/getting-started/apps/base/extension-content-operator/repository.yaml
+++ b/docs/getting-started/apps/base/extension-content-operator/repository.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: openmfp-system
 spec:
   interval: 5m
-  url: oci://ghcr.io/openmfp/extension-content-operator/helm/extension-content-operator
+  url: oci://ghcr.io/openmfp/helm-charts/extension-content-operator
   ref:
     semver: "*"
   secretRef:

--- a/docs/getting-started/apps/base/keycloak/repository.yaml
+++ b/docs/getting-started/apps/base/keycloak/repository.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: openmfp-system
 spec:
   interval: 5m
-  url: oci://ghcr.io/openmfp/keycloak/helm/keycloak
+  url: oci://ghcr.io/openmfp/helm-charts/keycloak
   ref:
     semver: "*"
   secretRef: # TODO: temporary as long as the repo is private

--- a/docs/getting-started/apps/base/portal/repository.yaml
+++ b/docs/getting-started/apps/base/portal/repository.yaml
@@ -5,8 +5,8 @@ metadata:
   namespace: openmfp-system
 spec:
   interval: 5m
-  url: oci://ghcr.io/openmfp/portal/helm/portal
+  url: oci://ghcr.io/openmfp/helm-charts/portal
   ref:
-    semver: 0.81.0
+    semver: 0.69.4
   secretRef:
     name: ghcr-credentials

--- a/docs/getting-started/infrastructure/controllers/infra.yaml
+++ b/docs/getting-started/infrastructure/controllers/infra.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: openmfp-system
 spec:
   interval: 5m
-  url: oci://ghcr.io/openmfp/infra/helm/infra
+  url: oci://ghcr.io/openmfp/helm-charts/infra
   ref:
     semver: "*"
   secretRef:


### PR DESCRIPTION
This updates the example setup script to use the new `openmfp/helm-charts` location and fixes a few instances of the image pull secret being not referenced properly.

The only thing I'm not quite sure about is the portal Helm chart version. The chart version 0.69.4 is _newer_ than 0.81.0 (because that is the app version), so it also upgrades the portal. I assume that's fine, but please check if that's okay (it updates portal from 0.81.0 to 0.84.0).