### PR TITLE
fix link to content configuration documentation

### DIFF
--- a/docs/getting-started/create-microfrontend.mdx
+++ b/docs/getting-started/create-microfrontend.mdx
@@ -49,7 +49,7 @@ Then open your browser and go to: http://localhost:4200/
 Create a new file called `content-configuration.json` in the `src/assets` folder of your Angular project or any path that will serve this file.
 This file will contain the configuration for your Microfrontend.
 
-The following is an example of very minimal content configuration file. The contents of this file are described in great detail at [Configuration Documentation](https://github.tools.sap/openmfp/portal-ui-lib/blob/main/docs/readme-nodes-configuration.md#the-content-configuration-file-contents).
+The following is an example of very minimal content configuration file. The contents of this file are described in great detail at [Configuration Documentation](https://github.com/openmfp/portal-ui-lib/blob/main/docs/readme-nodes-configuration.md#the-content-configuration-file-contents).
 
 ```json
 {


### PR DESCRIPTION
Link was pointing to internal github instead of github.com.