### PR TITLE
fix(config): adjust baseUrl for deployment

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -11,7 +11,7 @@ const config: Config = {
   url: 'https://your-docusaurus-site.example.com',
   // Set the /<baseUrl>/ pathname under which your site is served
   // For GitHub pages deployment, it is often '/<projectName>/'
-  baseUrl: 'openmfp.org/',
+  baseUrl: '/',
 
   // GitHub pages deployment config.
   // If you aren't using GitHub pages, you don't need these.


### PR DESCRIPTION
• Sets baseUrl to root for proper GitHub Pages serving