### PR TITLE
docs: add Zulip chat channels to community page

### DIFF
--- a/documentation/community.md
+++ b/documentation/community.md
@@ -30,7 +30,7 @@ OpenMFP chat lives on the [Linux Foundation Zulip server](https://linuxfoundatio
 
 ### Don't report security issues in chat
 
-Posting a vulnerability in public chat exposes it to potential attackers before a fix exists. Please follow our [security policy](https://github.com/openmfp/.github/blob/main/SECURITY.md) to report it through the project's private intake.
+Posting a vulnerability in public chat exposes it to potential attackers before a fix exists. Please follow our [security policy](https://github.com/openmfp/openmfp.org/security/policy) to report it through the project's private intake.
 
 ## Stay Updated
 

--- a/documentation/community.md
+++ b/documentation/community.md
@@ -19,8 +19,22 @@ We strive to maintain a respectful and inclusive environment. Please follow our 
 
 By participating, you agree to foster a positive, collaborative, and welcoming space for everyone.
 
+## Chat
+
+OpenMFP chat lives on the [Linux Foundation Zulip server](https://linuxfoundation.zulipchat.com/). Two channels cover most conversations.
+
+| Channel | Use it for |
+| --- | --- |
+| [`neonephos-openmfp-discussion`](https://linuxfoundation.zulipchat.com/#narrow/channel/neonephos-openmfp-discussion) | Design discussions, RFCs, and general questions about OpenMFP. |
+| [`neonephos-openmfp-support`](https://linuxfoundation.zulipchat.com/#narrow/channel/neonephos-openmfp-support) | Help with installing, running, or operating OpenMFP. |
+
+### Don't report security issues in chat
+
+Posting a vulnerability in public chat exposes it to potential attackers before a fix exists. Please follow our [security policy](https://github.com/openmfp/.github/blob/main/SECURITY.md) to report it through the project's private intake.
+
 ## Stay Updated
 
 - **Engage on GitHub Discussions**: Join the conversation and collaborate with the community.
+- **Chat on Zulip**: Join the [Linux Foundation Zulip server](https://linuxfoundation.zulipchat.com/) for real-time discussions.
 
 


### PR DESCRIPTION
## Summary

- Adds a new **Chat** section to the community page with the two Linux Foundation Zulip channels (`neonephos-openmfp-discussion` and `neonephos-openmfp-support`)
- Includes a security note to not report vulnerabilities in public chat
- Updates the "Stay Updated" section to include a Zulip link

Follows the same pattern as the [Platform Mesh chat page](https://github.com/platform-mesh/platform-mesh.github.io/blob/main/community/chat.md).

## Test plan

- [ ] Preview the rendered page and verify channel links and table format look correct

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a dedicated Chat section describing the OpenMFP Zulip community channels and their purposes.
  * Added guidance to report security issues privately through the security policy rather than public chat.
  * Updated the Stay Updated section with Zulip chat participation details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->